### PR TITLE
Fix warnings + approval in constructor + allowing to hot wallet to do…

### DIFF
--- a/src/VoteProxy.sol
+++ b/src/VoteProxy.sol
@@ -25,6 +25,11 @@ contract VoteProxy {
     _;
   }
 
+  function approve(uint amt) public canExecute {
+    gov.approve(chief, amt);
+    iou.approve(chief, amt);
+  }
+
   function lock(uint amt) public canExecute {
     chief.lock(amt);
   }

--- a/src/VoteProxy.sol
+++ b/src/VoteProxy.sol
@@ -10,48 +10,43 @@ contract VoteProxy {
   DSToken iou;
   DSChief chief;
 
-  function VoteProxy(DSToken gov_, DSChief chief_, DSToken iou_, address cold_, address hot_) {
+  function VoteProxy(DSToken gov_, DSChief chief_, DSToken iou_, address cold_, address hot_) public {
     cold = cold_;
     hot = hot_;
     gov = gov_;
     chief = chief_;
     iou = iou_;
+    gov.approve(chief, uint(-1));
+    iou.approve(chief, uint(-1));
   }
 
-  function approve(uint amt) {
-    require(msg.sender == cold);
-    gov.approve(chief, amt);
-    iou.approve(chief, amt);
+  modifier canExecute() {
+    require(msg.sender == hot || msg.sender == cold);
+    _;
   }
 
-  function lock(uint amt) public {
-    require(msg.sender == cold);
+  function lock(uint amt) public canExecute {
     chief.lock(amt);
   }
 
-  function free(uint amt) public {
-    require(msg.sender == cold);
+  function free(uint amt) public canExecute {
     chief.free(amt);
   }
 
-  function withdraw(uint amt) public {
-    require(msg.sender == cold);
+  function withdraw(uint amt) public canExecute {
     gov.transfer(cold, amt);
   }
 
   // actions which can be called from the hot wallet
-  function vote(address[] yays) public returns (bytes32 slate) {
-    require(msg.sender == hot || msg.sender == cold);
+  function vote(address[] yays) public canExecute returns (bytes32 slate) {
     return chief.vote(yays);
   }
 
-  function vote(bytes32 slate) public {
-    require(msg.sender == hot || msg.sender == cold);
+  function vote(bytes32 slate) public canExecute {
     chief.vote(slate);
   }
 
-  function etch(address[] yays) public returns (bytes32 slate) {
-    require(msg.sender == hot || msg.sender == cold);
+  function etch(address[] yays) public canExecute returns (bytes32 slate) {
     return chief.etch(yays);
   }
 

--- a/src/VoteProxy.t.sol
+++ b/src/VoteProxy.t.sol
@@ -39,6 +39,10 @@ contract ChiefUser {
     proxy.free(amt);
   }
 
+  function doProxyApprove(uint amt) public {
+    proxy.approve(amt);
+  }
+
   function doLock(uint amt) public {
     chief.lock(amt);
   }
@@ -219,6 +223,12 @@ contract VoteProxyTest is DSTest {
       require(chief.approvals(c1) == 100 ether);
     }
 
+    function testFail_no_proxy_approval() public {
+      cold.doTransfer(proxy, 100 ether);
+      cold.doProxyApprove(0);
+      cold.doProxyLock(100 ether);
+    }
+
     function testFail_random_withdrawal() public {
       cold.doTransfer(proxy, 100 ether);
       require(gov.balanceOf(cold) == 0);
@@ -237,6 +247,4 @@ contract VoteProxyTest is DSTest {
       random.doProxyVote(uLargeSlate);
       require(chief.approvals(c1) == 100 ether);
     }
-
-
 }

--- a/src/VoteProxy.t.sol
+++ b/src/VoteProxy.t.sol
@@ -12,7 +12,7 @@ contract ChiefUser {
   DSChief chief;
   VoteProxy proxy;
 
-  function ChiefUser(DSToken gov_, DSToken iou_, DSChief chief_) {
+  function ChiefUser(DSToken gov_, DSToken iou_, DSChief chief_) public {
     iou = iou_;
     gov = gov_;
     chief = chief_;
@@ -22,7 +22,7 @@ contract ChiefUser {
     proxy = proxy_;
   }
 
-  function doTransfer(address to, uint amt) {
+  function doTransfer(address to, uint amt) public {
     gov.transfer(to, amt);
   }
 
@@ -37,10 +37,6 @@ contract ChiefUser {
 
   function doProxyFree(uint amt) public {
     proxy.free(amt);
-  }
-
-  function doProxyApprove(uint amt) public {
-    proxy.approve(amt);
   }
 
   function doLock(uint amt) public {
@@ -72,7 +68,7 @@ contract VoteProxyTest is DSTest {
     uint256 constant initialBalance = 1000 ether;
     uint256 constant electionSize = 3;
 
-     address constant c1 = 0x1;
+    address constant c1 = 0x1;
 
     VoteProxy proxy;
     DSToken gov;
@@ -87,7 +83,7 @@ contract VoteProxyTest is DSTest {
         gov = new DSToken("GOV");
         gov.mint(initialBalance);
 
-        var fab = new DSChiefFab();
+        DSChiefFab fab = new DSChiefFab();
         chief = fab.newChief(gov, electionSize);
         iou = chief.IOU();
 
@@ -135,7 +131,6 @@ contract VoteProxyTest is DSTest {
       require(gov.balanceOf(proxy) == 100 ether);
       require(gov.balanceOf(chief) == 0);
 
-      cold.doProxyApprove(100 ether);
       cold.doProxyLock(100 ether);
       require(gov.balanceOf(cold) == 0);
       require(gov.balanceOf(proxy) == 0);
@@ -152,13 +147,38 @@ contract VoteProxyTest is DSTest {
       require(gov.balanceOf(chief) == 0);
     }
 
+    function test_hot_lock_free() public {
+      require(gov.balanceOf(cold) == 100 ether);
+      require(gov.balanceOf(proxy) == 0);
+      require(gov.balanceOf(chief) == 0);
+
+      cold.doTransfer(proxy, 100 ether);
+      require(gov.balanceOf(cold) == 0);
+      require(gov.balanceOf(proxy) == 100 ether);
+      require(gov.balanceOf(chief) == 0);
+
+      hot.doProxyLock(100 ether);
+      require(gov.balanceOf(cold) == 0);
+      require(gov.balanceOf(proxy) == 0);
+      require(gov.balanceOf(chief) == 100 ether);
+
+      hot.doProxyFree(100 ether);
+      require(gov.balanceOf(cold) == 0);
+      require(gov.balanceOf(proxy) == 100 ether);
+      require(gov.balanceOf(chief) == 0);
+
+      hot.doWithdraw(100 ether);
+      require(gov.balanceOf(cold) == 100 ether);
+      require(gov.balanceOf(proxy) == 0);
+      require(gov.balanceOf(chief) == 0);
+    }
+
     function test_hot_proxy_voting_etch() public {
       // setup
       cold.doTransfer(proxy, 100 ether);
-      cold.doProxyApprove(100 ether);
       cold.doProxyLock(100 ether);
 
-      var uLargeSlate = new address[](1);
+      address[] memory uLargeSlate = new address[](1);
       uLargeSlate[0] = c1;
       bytes32 slate = hot.doProxyEtch(uLargeSlate);
       hot.doProxyVote(slate);
@@ -168,10 +188,9 @@ contract VoteProxyTest is DSTest {
     function test_cold_proxy_voting_etch() public {
       // setup
       cold.doTransfer(proxy, 100 ether);
-      cold.doProxyApprove(100 ether);
       cold.doProxyLock(100 ether);
 
-      var uLargeSlate = new address[](1);
+      address[] memory uLargeSlate = new address[](1);
       uLargeSlate[0] = c1;
       bytes32 slate = cold.doProxyEtch(uLargeSlate);
       cold.doProxyVote(slate);
@@ -181,10 +200,9 @@ contract VoteProxyTest is DSTest {
     function test_hot_proxy_voting_array() public {
       // setup
       cold.doTransfer(proxy, 100 ether);
-      cold.doProxyApprove(100 ether);
       cold.doProxyLock(100 ether);
 
-      var uLargeSlate = new address[](1);
+      address[] memory uLargeSlate = new address[](1);
       uLargeSlate[0] = c1;
       hot.doProxyVote(uLargeSlate);
       require(chief.approvals(c1) == 100 ether);
@@ -193,21 +211,12 @@ contract VoteProxyTest is DSTest {
     function test_cold_proxy_voting_array() public {
       // setup
       cold.doTransfer(proxy, 100 ether);
-      cold.doProxyApprove(100 ether);
       cold.doProxyLock(100 ether);
 
-      var uLargeSlate = new address[](1);
+      address[] memory uLargeSlate = new address[](1);
       uLargeSlate[0] = c1;
       cold.doProxyVote(uLargeSlate);
       require(chief.approvals(c1) == 100 ether);
-    }
-
-    function testFail_hot_withdrawal() public {
-      cold.doTransfer(proxy, 100 ether);
-      require(gov.balanceOf(cold) == 0);
-      require(gov.balanceOf(proxy) == 100 ether);
-
-      hot.doWithdraw(100 ether);
     }
 
     function testFail_random_withdrawal() public {
@@ -221,10 +230,9 @@ contract VoteProxyTest is DSTest {
     function testFail_random_vote() public {
       // setup
       cold.doTransfer(proxy, 100 ether);
-      cold.doProxyApprove(100 ether);
       cold.doProxyLock(100 ether);
 
-      var uLargeSlate = new address[](1);
+      address[] memory uLargeSlate = new address[](1);
       uLargeSlate[0] = c1;
       random.doProxyVote(uLargeSlate);
       require(chief.approvals(c1) == 100 ether);


### PR DESCRIPTION
… all actions

@apmilen @mhhf 
This PR fixes a couple of solidity warnings and propose two changes:
- Approval of `gov` and `iou` in the constructor. I do not see a real reason why we would need to set different allowances for `vote-proxy` to the `chief`.

- Allow `hot` wallet to do all the same actions than `cold`. I believe we want to avoid to use the `cold` wallet the much as possible. So with this solution `cold` wallet just will be used to send funds to the `vote-proxy`, then with the `hot` wallet is possible to manage everything, even the `withdraw`, I think the important thing here is to always send the funds back to the `cold` wallet.