### PR TITLE
First version of the vote proxy factory with registries

### DIFF
--- a/src/VoteProxyFactory.sol
+++ b/src/VoteProxyFactory.sol
@@ -8,25 +8,35 @@ contract VoteProxyFactory {
     DSToken public iou;
     mapping(address=>VoteProxy) public hotMap;
     mapping(address=>VoteProxy) public coldMap;
+    mapping(address=>address) public desiredLink;
     
     constructor(DSChief chief_) public {
         chief = chief_;
         gov = chief.GOV();
         iou = chief.IOU();
     }
-    
-    function newVoteProxy(address cold_, address hot_) public returns (VoteProxy voteProxy) {
-        require(cold_ == msg.sender, "Vote Proxy must be created by cold wallet");
-        require(
-            coldMap[cold_] == address(0) && hotMap[cold_] == address(0), 
-            "Cold wallet cannot already have a Vote Proxy associated with it"
+
+    function approveLink(address cold_) public returns (VoteProxy voteProxy) {
+        address hot_ = msg.sender;
+        requre(
+            desiredLink[cold_] == hot_, 
+            "Cold wallet must have initiated a link"
             );
-       require(
+        require(
             coldMap[hot_] == address(0) && hotMap[hot_] == address(0), 
             "Hot wallet cannot already have a Vote Proxy associated with it"
             );
         voteProxy = new VoteProxy(gov, chief, iou, cold_, hot_);
         hotMap[hot_] = voteProxy;
         coldMap[cold_] = voteProxy;
+    }
+    
+    function initiateLink(address hot_) public {
+        address cold_ = msg.sender;
+        require(
+            coldMap[cold_] == address(0) && hotMap[cold_] == address(0), 
+            "Cold wallet cannot already have a Vote Proxy associated with it"
+            );
+        desiredLink[cold_] = hot_;
     }
 }

--- a/src/VoteProxyFactory.sol
+++ b/src/VoteProxyFactory.sol
@@ -1,0 +1,32 @@
+pragma solidity ^0.4.21;
+
+import "./VoteProxy.sol";
+
+contract VoteProxyFactory {
+    DSChief public chief;
+    DSToken public gov;
+    DSToken public iou;
+    mapping(address=>VoteProxy) public hotMap;
+    mapping(address=>VoteProxy) public coldMap;
+    
+    constructor(DSChief chief_) public {
+        chief = chief_;
+        gov = chief.GOV();
+        iou = chief.IOU();
+    }
+    
+    function newVoteProxy(address cold_, address hot_) public returns (VoteProxy voteProxy) {
+        require(cold_ == msg.sender, "Vote Proxy must be created by cold wallet");
+        require(
+            coldMap[cold_] == address(0) && hotMap[cold_] == address(0), 
+            "Cold wallet cannot already have a Vote Proxy associated with it"
+            );
+       require(
+            coldMap[hot_] == address(0) && hotMap[hot_] == address(0), 
+            "Hot wallet cannot already have a Vote Proxy associated with it"
+            );
+        voteProxy = new VoteProxy(gov, chief, iou, cold_, hot_);
+        hotMap[hot_] = voteProxy;
+        coldMap[cold_] = voteProxy;
+    }
+}

--- a/src/VoteProxyFactory.sol
+++ b/src/VoteProxyFactory.sol
@@ -16,27 +16,29 @@ contract VoteProxyFactory {
         iou = chief.IOU();
     }
 
-    function approveLink(address cold_) public returns (VoteProxy voteProxy) {
-        address hot_ = msg.sender;
-        requre(
-            desiredLink[cold_] == hot_, 
-            "Cold wallet must have initiated a link"
-            );
-        require(
-            coldMap[hot_] == address(0) && hotMap[hot_] == address(0), 
-            "Hot wallet cannot already have a Vote Proxy associated with it"
-            );
-        voteProxy = new VoteProxy(gov, chief, iou, cold_, hot_);
-        hotMap[hot_] = voteProxy;
-        coldMap[cold_] = voteProxy;
+    function approveLink(address cold) public returns (VoteProxy voteProxy) {
+        address hot = msg.sender;
+
+        bool mutualInterest = desiredLink[cold] == hot;
+        requre(mutualInterest, "Cold wallet must have initiated a link");
+
+        bool hotHasProxy = coldMap[hot] != address(0) || hotMap[hot] != address(0);
+        require(!hotHasProxy, "Hot wallet cannot already have a Vote Proxy associated with it");
+
+        voteProxy = new VoteProxy(gov, chief, iou, cold, hot);
+        hotMap[hot] = voteProxy;
+        coldMap[cold] = voteProxy;
     }
     
-    function initiateLink(address hot_) public {
-        address cold_ = msg.sender;
-        require(
-            coldMap[cold_] == address(0) && hotMap[cold_] == address(0), 
-            "Cold wallet cannot already have a Vote Proxy associated with it"
-            );
-        desiredLink[cold_] = hot_;
+    function initiateLink(address hot) public {
+        address cold = msg.sender;
+
+        bool coldHasProxy = coldMap[cold] != address(0) || hotMap[cold] != address(0);
+        require(!coldHasProxy, "Cold wallet cannot already have a Vote Proxy associated with it");
+
+        bool hotHasProxy = coldMap[hot] != address(0) || hotMap[hot] != address(0);
+        require(!hotHasProxy, "Hot wallet cannot already have a Vote Proxy associated with it");
+
+        desiredLink[cold] = hot;
     }
 }

--- a/src/VoteProxyFactory.sol
+++ b/src/VoteProxyFactory.sol
@@ -28,6 +28,7 @@ contract VoteProxyFactory {
 
         require(!hasProxy(cold), "Cold wallet cannot already be linked to a Vote Proxy");
         require(!hasProxy(hot), "Hot wallet cannot already be linked to a Vote Proxy");
+        require(cold != hot, "Hot wallet cannot be the same as the cold wallet"); // should we allow this?
 
         linkRequests[cold] = hot;
         emit LinkRequested(cold, hot);
@@ -37,7 +38,7 @@ contract VoteProxyFactory {
         address hot = msg.sender;
 
         bool mutualInterest = linkRequests[cold] == hot;
-        requre(mutualInterest, "Cold wallet must initiate a link first");
+        require(mutualInterest, "Cold wallet must initiate a link first");
         require(!hasProxy(hot), "Hot wallet cannot already be linked to a Vote Proxy");
 
         voteProxy = new VoteProxy(gov, chief, iou, cold, hot);


### PR DESCRIPTION
**Basic Functionality**
Create a `vote-proxy` with designated hot and cold addresses for the voter 

**What we want to be able to do quickly**
* Check whether a given address has a `vote-proxy` 
  * If an address has a proxy, quickly check whether it is `hot` or `cold` & get the address of its `vote-proxy` if so

**Security/ Ease-of-use**
* Ensure the voter has control of `hot` & `cold` before creating a proxy for them or adding them them to a registry
* Once a link between two addresses has been established, blacklist addresses –> ie allow neither to be used again as `hot` *or* `cold` because...

<div align="center">we want to avoid</div>

1.
![multi-cold](https://user-images.githubusercontent.com/24902242/42786012-2bb4a858-891a-11e8-9d32-8ec06a37d2ee.png)

<div align="center">and</div>

2.
![hot-cold-chain](https://user-images.githubusercontent.com/24902242/42786202-edf503a4-891a-11e8-99aa-c886176b2763.png)



**Todo**
* Tests



